### PR TITLE
Add Codebase Quality Checking GitHub Action

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,17 @@
+name: Checks
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Checks
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - run: pip install --upgrade pip
+    - run: pip install "black<23" pylint==v3.0.0a3 mypy==v0.902
+    - run: black --diff --check $(git ls-files '*.py')
+    - run: pylint --disable=all --enable=unused-import $(git ls-files '*.py')
+    - run: mypy --strict $(git ls-files '*.py')

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -14,4 +14,4 @@ jobs:
     - run: pip install "black<23" pylint==v3.0.0a3 mypy==v0.902
     - run: black --diff --check $(git ls-files '*.py')
     - run: pylint --disable=all --enable=unused-import $(git ls-files '*.py')
-    - run: mypy --strict $(git ls-files '*.py')
+    - run: mypy --ignore-missing-imports --strict $(git ls-files '*.py')

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         python-version: 3.9.13
     - run: pip install --upgrade pip
-    - run: pip install "black<23" pylint==v3.0.0a3 mypy==v0.902
+    - run: pip install "black<23" pylint==v3.0.0a3 mypy==v0.991
     - run: black --diff --check $(git ls-files '*.py')
     - run: pylint --disable=all --enable=unused-import $(git ls-files '*.py')
-    - run: mypy --ignore-missing-imports --no-warn-return-any --strict $(git ls-files '*.py')
+    - run: mypy --allow-untyped-decorators --ignore-missing-imports --no-warn-return-any --strict $(git ls-files '*.py')

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.x
+        python-version: 3.9.13
     - run: pip install --upgrade pip
     - run: pip install "black<23" pylint==v3.0.0a3 mypy==v0.902
     - run: black --diff --check $(git ls-files '*.py')

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -14,4 +14,4 @@ jobs:
     - run: pip install "black<23" pylint==v3.0.0a3 mypy==v0.902
     - run: black --diff --check $(git ls-files '*.py')
     - run: pylint --disable=all --enable=unused-import $(git ls-files '*.py')
-    - run: mypy --ignore-missing-imports --strict $(git ls-files '*.py')
+    - run: mypy --ignore-missing-imports --no-warn-return-any --strict $(git ls-files '*.py')

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+.mypy_cache
+.pytest_cache

--- a/core/BaseMQTTPubSub.py
+++ b/core/BaseMQTTPubSub.py
@@ -2,7 +2,7 @@
 incorporates a dynamic message/event-based infrastructure that is enabled via MQTT.
 This is very much a working document and is under active development.
 """
-from typing import Callable, Any
+from typing import Callable, Any, Dict, List
 import paho.mqtt.client as mqtt
 
 
@@ -17,7 +17,7 @@ class BaseMQTTPubSub:
     HEARTBEAT_FREQUENCY = 10  # seconds
 
     def __init__(
-        self,
+        self: Any,
         config_path: str = CONFIG_PATH,
         heartbeat_topic: str = HEARTBEAT_TOPIC,
         heartbeat_frequency: int = HEARTBEAT_FREQUENCY,
@@ -46,7 +46,7 @@ class BaseMQTTPubSub:
 
         self.client = mqtt.Client()
 
-    def _parse_config(self) -> dict:
+    def _parse_config(self: Any) -> Dict[str, str]:
         """Parses the config at the specified path from the constructor where the equal sign
         connects the key with the value and each pair is newline delimited (assumes utf-8 encoded).
 
@@ -60,14 +60,17 @@ class BaseMQTTPubSub:
             }
             return parameters
 
-    def connect_client(self) -> None:
+    def connect_client(self: Any) -> None:
         """Properly add a client connection to the MQTT server that includes a callback, which
         verifies that the connection was successful.
         """
 
         def _on_connect(
-            _client: mqtt.Client, _userdata: Any, _flags: dict, response_flag: int
-        ):
+            _client: mqtt.Client,
+            _userdata: Any,
+            _flags: Dict[Any, Any],
+            response_flag: int,
+        ) -> None:
             """Connection callback that stores the result of connecting in a flag for class-wide
             access to verify the connection—can be overridden for more elaborate usage.
 
@@ -101,12 +104,14 @@ class BaseMQTTPubSub:
         )
         self.client.loop_start()  # start callback thread
 
-    def graceful_stop(self) -> None:
+    def graceful_stop(self: Any) -> None:
         """How to properly shutoff the MQTT client connection that includes a callback to signal
         if the disconnect was successful.
         """
 
-        def _on_disconnect(_client: mqtt.Client, _userdata: Any, response_flag: int):
+        def _on_disconnect(
+            _client: mqtt.Client, _userdata: Any, response_flag: int
+        ) -> None:
             """Disconnect callback that stores the result of diconnecting in a flag for class-wide
             access to verify the disconect—can be overridden for more elaborate usage.
 
@@ -127,7 +132,7 @@ class BaseMQTTPubSub:
         self.client.loop_stop()  # TODO: not sure if this is necessary
 
     def setup_ungraceful_disconnect_publish(
-        self,
+        self: Any,
         ungraceful_disconnect_topic: str,
         ungraceful_disconnect_payload: str,
         qos: int = 0,
@@ -147,13 +152,16 @@ class BaseMQTTPubSub:
         )  # TODO: this function is untested
 
     def add_subscribe_topic(
-        self, topic_name: str, callback_method: Callable, qos: int = 2
+        self: Any,
+        topic_name: str,
+        callback_method: Callable[[mqtt.Client, Dict[Any, Any], Any], None],
+        qos: int = 2,
     ) -> bool:
         """Adds a callback to the topic specified with the specified quality of service.
 
         Args:
             topic_name (str): topic name to subscribe to.
-            callback_method (Callable): callback function to return information.
+            callback_method (Callable[[mqtt.Client, Dict[Any, Any], Any], None]): callback function to return information.
             qos (int, optional): MQTT quality of service options 0, 1, or 2. Defaults to 2.
 
         Returns:
@@ -164,10 +172,10 @@ class BaseMQTTPubSub:
         return result == mqtt.MQTT_ERR_SUCCESS  # returns True if successful
 
     def add_subscribe_topics(
-        self,
-        topic_list: list[str],
-        callback_method_list: list[Callable],
-        qos_list: list[int],
+        self: Any,
+        topic_list: List[str],
+        callback_method_list: List[Callable[[mqtt.Client, Dict[Any, Any], Any], None]],
+        qos_list: List[int],
     ) -> bool:
         """Adds topics, callbacks, and quality of services from lists and adds
         callbacks that subscribe topics of interest and returns True if all
@@ -175,7 +183,7 @@ class BaseMQTTPubSub:
 
         Args:
             topic_list (list[str]): list of topics to subscribe to.
-            callback_method_list (list[Callable]): list of callback functions to recieve callbacks.
+            callback_method_list (list[Callable[[mqtt.Client, Dict[Any, Any], Any], None]]): list of callback functions to recieve callbacks.
             qos_list (list[str]): list of integers that correspond to the QoS requirements.
 
         Returns:
@@ -191,7 +199,7 @@ class BaseMQTTPubSub:
             topic_list
         )  # returns True if all successful
 
-    def remove_subscribe_topic(self, topic_name: str) -> None:
+    def remove_subscribe_topic(self: Any, topic_name: str) -> None:
         """A wrapper around paho MQTT callback removal funciton, which does not send a
         success message so nothing is returned (TODO: is make a PR on the paho GitHub).
 
@@ -201,7 +209,11 @@ class BaseMQTTPubSub:
         self.client.message_callback_remove(topic_name)
 
     def publish_to_topic(
-        self, topic_name: str, publish_payload: str, qos: int = 2, retain: bool = False
+        self: Any,
+        topic_name: str,
+        publish_payload: str,
+        qos: int = 2,
+        retain: bool = False,
     ) -> bool:
         """A wrapper around the paho MQTT publishing function publshes a payload to
         a topic name and returns True if successful.
@@ -218,7 +230,7 @@ class BaseMQTTPubSub:
         (result, _mid) = self.client.publish(topic_name, publish_payload, qos, retain)
         return result == mqtt.MQTT_ERR_SUCCESS  # returns True if successful
 
-    def publish_hearbeat(self, payload: str) -> bool:
+    def publish_hearbeat(self: Any, payload: str) -> bool:
         """A function that includes a hearbeat publisher. To call this function correctly,
         you will need to use the python schedule module around this function or put this in
         your main loop with a tick of self.heartbeat_frequency b/c MQTT is single threaded.

--- a/core/BaseMQTTPubSubTest.py
+++ b/core/BaseMQTTPubSubTest.py
@@ -4,12 +4,12 @@
 from time import sleep
 import paho.mqtt.client as mqtt
 import pytest
-from typing import Callable
+from typing import Callable, Dict, Any
 from BaseMQTTPubSub import BaseMQTTPubSub
 
 
-@pytest.fixture
-def basepubsub():
+@pytest.fixture()
+def basepubsub() -> BaseMQTTPubSub:
     """Pytest fixture that returns an instance of the BaseMQTTPubSub class for testing.
 
     Returns:
@@ -19,17 +19,17 @@ def basepubsub():
 
 
 @pytest.fixture
-def config_parse_result():
+def config_parse_result() -> Dict[str, str]:
     """Pytest fixture for the current expected config parse results.
 
     Returns:
         dict: maps string keys to their values as they appear in the current config.
     """
-    return {"IP": "127.0.0.1", "PORT": "8883", "TIMEOUT": "60"}
+    return {"IP": "127.0.0.1", "PORT": "1883", "TIMEOUT": "60"}
 
 
 @pytest.fixture
-def ungraceful_disconnect_topic():
+def ungraceful_disconnect_topic() -> str:
     """Pytest fixture topic name for the ungraceful last will and testament broadcast.
 
     Returns:
@@ -39,7 +39,7 @@ def ungraceful_disconnect_topic():
 
 
 @pytest.fixture
-def ungraceful_disconnect_payload():
+def ungraceful_disconnect_payload() -> str:
     """Pytest fixture payload for the ungraceful last will and testament broadcast.
 
     Returns:
@@ -49,7 +49,7 @@ def ungraceful_disconnect_payload():
 
 
 @pytest.fixture
-def fixture_topic_one():
+def fixture_topic_one() -> str:
     """Pytest fixture topic name for subscriber testing.
 
     Returns:
@@ -59,7 +59,7 @@ def fixture_topic_one():
 
 
 @pytest.fixture
-def fixture_callback_one():
+def fixture_callback_one() -> Callable[[mqtt.Client, Dict[Any, Any], Any], None]:
     """Pytest fixture that defines a nested funciton that will serve as the callback function
     for the topic one test.
 
@@ -67,15 +67,17 @@ def fixture_callback_one():
         Callable: the callback function defined in the fixture.
     """
 
-    def _callback_one(_client: mqtt.Client, _userdata: dict, msg: str) -> str:
+    def _callback_one(
+        _client: mqtt.Client, _userdata: Dict[Any, Any], msg: Any
+    ) -> None:
         """Standard callback fuction that prints the recieved message and topic name it is
         subscribed to.
 
         Args:
             _client (mqtt.Client): the MQTT client that was instatntiated in the constructor.
-            _userdata (Any): data passed to the callback through the MQTT paho Client
+            _userdata (Dict[Any,Any]): data passed to the callback through the MQTT paho Client
             class contructor or set later through user_data_set().
-            msg (str): the recieved message over the subscribed channel that includes
+            msg (Any): the recieved message over the subscribed channel that includes
             the topic name and payload after decoding.
         """
         print("Message Topic:", msg.topic)
@@ -85,7 +87,7 @@ def fixture_callback_one():
 
 
 @pytest.fixture
-def fixture_payload_one():
+def fixture_payload_one() -> str:
     """Pytest fixture that defines the payload to be published to the fixture_topic_one topic.
 
     Returns:
@@ -95,7 +97,7 @@ def fixture_payload_one():
 
 
 @pytest.fixture
-def fixture_topic_two():
+def fixture_topic_two() -> str:
     """Pytest fixture topic name for multi-subscriber testing.
 
     Returns:
@@ -105,7 +107,7 @@ def fixture_topic_two():
 
 
 @pytest.fixture
-def fixture_callback_two():
+def fixture_callback_two() -> Callable[[mqtt.Client, Dict[Any, Any], Any], None]:
     """Pytest fixture that defines a nested funciton that will serve as the callback function
     for multiple subscriber test.
 
@@ -113,15 +115,17 @@ def fixture_callback_two():
         Callable: the callback function defined in the fixture.
     """
 
-    def _callback_two(_client: mqtt.Client, _userdata: dict, msg: str) -> str:
+    def _callback_two(
+        _client: mqtt.Client, _userdata: Dict[Any, Any], msg: Any
+    ) -> None:
         """Standard callback fuction that prints the recieved message and topic name it is
         subscribed to.
 
         Args:
             _client (mqtt.Client): the MQTT client that was instatntiated in the constructor.
-            _userdata (Any): data passed to the callback through the MQTT paho Client
+            _userdata (Dict[Any,Any]): data passed to the callback through the MQTT paho Client
             class contructor or set later through user_data_set().
-            msg (str): the recieved message over the subscribed channel that includes
+            msg (Any): the recieved message over the subscribed channel that includes
             the topic name and payload after decoding.
         """
         print("Message Topic:", msg.topic)
@@ -131,7 +135,7 @@ def fixture_callback_two():
 
 
 @pytest.fixture
-def fixture_heartbeat_payload():
+def fixture_heartbeat_payload() -> str:
     """Pytest fixture that defines the payload published to the heartbeat topic name defined
     in the BaseMQTTPubSub constructor.
 
@@ -143,7 +147,7 @@ def fixture_heartbeat_payload():
 
 
 @pytest.fixture
-def fixture_heartbeat_callback():
+def fixture_heartbeat_callback() -> Callable[[mqtt.Client, Dict[Any, Any], Any], None]:
     """pytest fixture that returns a callback for the heartbeat topic to verify that
     the published payload has been recieved correcrtly and shows and example usage of
     the userdata component of MQTT callbacks.
@@ -152,15 +156,17 @@ def fixture_heartbeat_callback():
         Callable: the callback function defined in the fixture.
     """
 
-    def _heartbeat_callback(client: mqtt.Client, _userdata: dict, msg: str) -> str:
+    def _heartbeat_callback(
+        client: mqtt.Client, _userdata: Dict[Any, Any], msg: Any
+    ) -> None:
         """Heartbeat callback function that prints the payload and topic name as well
         as stores the decoded payload in the userdata attribute of the client.
 
         Args:
             client (mqtt.Client): the MQTT client that was instatntiated in the constructor.
-            _userdata (Any): data passed to the callback through the MQTT paho Client
+            _userdata (Dict[Any,Any]): data passed to the callback through the MQTT paho Client
             class contructor or set later through user_data_set().
-            msg (str): the recieved message over the subscribed channel that includes
+            msg (Any): the recieved message over the subscribed channel that includes
             the topic name and payload after decoding.
         """
         print("Message Topic:", msg.topic)
@@ -171,7 +177,9 @@ def fixture_heartbeat_callback():
     return _heartbeat_callback
 
 
-def test_pase_config(basepubsub: BaseMQTTPubSub, config_parse_result: dict):
+def test_pase_config(
+    basepubsub: BaseMQTTPubSub, config_parse_result: Dict[str, str]
+) -> None:
     """Using the pytest module, this function verifies that the parsed config function
     output matches the expected fixture.
 
@@ -183,7 +191,7 @@ def test_pase_config(basepubsub: BaseMQTTPubSub, config_parse_result: dict):
     assert basepubsub.client_connection_parameters == config_parse_result
 
 
-def test_connect_client(basepubsub: BaseMQTTPubSub):
+def test_connect_client(basepubsub: BaseMQTTPubSub) -> bool:
     """Using the pytest module, this function verifies that the connection function
     effectively connects to the MQTT broker running on the device from the persepective
     of the broker.
@@ -198,7 +206,7 @@ def test_connect_client(basepubsub: BaseMQTTPubSub):
     assert basepubsub.connection_flag is True  # successful connection
 
 
-def test_graceful_stop(basepubsub: BaseMQTTPubSub):
+def test_graceful_stop(basepubsub: BaseMQTTPubSub) -> bool:
     """Using the pytest module, this function verifies that the graceful disconnect
     function effectively disconnects from the MQTT broker from its perspective.
 
@@ -219,7 +227,7 @@ def test_setup_ungraceful_disconnect_publish(
     basepubsub: BaseMQTTPubSub,
     ungraceful_disconnect_topic: str,
     ungraceful_disconnect_payload: str,
-):
+) -> None:
     """Using the pytest module, this function is meant to verify that the last will and
     testament publish occurs if the connected client disconnects unexpectedly
     (without calling disconnect).
@@ -238,8 +246,10 @@ def test_setup_ungraceful_disconnect_publish(
 
 
 def test_add_subscribe_topic(
-    basepubsub: BaseMQTTPubSub, fixture_topic_one: str, fixture_callback_one: Callable
-):
+    basepubsub: BaseMQTTPubSub,
+    fixture_topic_one: str,
+    fixture_callback_one: Callable[[mqtt.Client, Dict[Any, Any], Any], None],
+) -> bool:
     """Using the pytest module, this funciton is meant to verify the successful addition
     of a subscriber to the specified topic from the perspective of the MQTT broker.
 
@@ -259,10 +269,10 @@ def test_add_subscribe_topic(
 def test_add_subscribe_topics(
     basepubsub: BaseMQTTPubSub,
     fixture_topic_one: str,
-    fixture_callback_one: Callable,
+    fixture_callback_one: Callable[[mqtt.Client, Dict[Any, Any], Any], None],
     fixture_topic_two: str,
-    fixture_callback_two: Callable,
-):
+    fixture_callback_two: Callable[[mqtt.Client, Dict[Any, Any], Any], None],
+) -> bool:
     """Using the pytest module, this funciton is meant to verify the successful addition
     of multiple subscribers to the specified topics from the perspective of the MQTT broker
 
@@ -288,8 +298,10 @@ def test_add_subscribe_topics(
 
 
 def test_remove_subscribe_topic(
-    basepubsub: BaseMQTTPubSub, fixture_topic_one: str, fixture_callback_one: Callable
-):
+    basepubsub: BaseMQTTPubSub,
+    fixture_topic_one: str,
+    fixture_callback_one: Callable[[mqtt.Client, Dict[Any, Any], Any], None],
+) -> None:
     """Using the pytest module, this funciton calls the remove subscriber funciton,
     but will require additional development specified in the TODO to fully verify its accuracy.
 
@@ -315,7 +327,7 @@ def test_remove_subscribe_topic(
 
 def test_publish_to_topic(
     basepubsub: BaseMQTTPubSub, fixture_topic_one: str, fixture_payload_one: str
-):
+) -> bool:
     """Using the pytest module, this function tests successful publishing from the
     perspective of the MQTT broker.
 
@@ -335,8 +347,8 @@ def test_publish_to_topic(
 def test_publish_heartbeat(
     basepubsub: BaseMQTTPubSub,
     fixture_heartbeat_payload: str,
-    fixture_heartbeat_callback: Callable,
-):
+    fixture_heartbeat_callback: Callable[[mqtt.Client, Dict[Any, Any], Any], None],
+) -> bool:
     """Using the pytest module, his funciton tests multiple functionalities defiend in the class and can be considered
     a verification of the heartbeat function, the publish function, and the subscriber function
     as it publishes a payload to the heartbeat topic specified in the constructor of the class

--- a/core/BaseMQTTPubSubTest.py
+++ b/core/BaseMQTTPubSubTest.py
@@ -18,7 +18,7 @@ def basepubsub() -> BaseMQTTPubSub:
     return BaseMQTTPubSub()
 
 
-@pytest.fixture
+@pytest.fixture()
 def config_parse_result() -> Dict[str, str]:
     """Pytest fixture for the current expected config parse results.
 
@@ -28,7 +28,7 @@ def config_parse_result() -> Dict[str, str]:
     return {"IP": "127.0.0.1", "PORT": "1883", "TIMEOUT": "60"}
 
 
-@pytest.fixture
+@pytest.fixture()
 def ungraceful_disconnect_topic() -> str:
     """Pytest fixture topic name for the ungraceful last will and testament broadcast.
 
@@ -38,7 +38,7 @@ def ungraceful_disconnect_topic() -> str:
     return "/base/ungracefultest"
 
 
-@pytest.fixture
+@pytest.fixture()
 def ungraceful_disconnect_payload() -> str:
     """Pytest fixture payload for the ungraceful last will and testament broadcast.
 
@@ -48,7 +48,7 @@ def ungraceful_disconnect_payload() -> str:
     return "The process ungracefully disconnected"
 
 
-@pytest.fixture
+@pytest.fixture()
 def fixture_topic_one() -> str:
     """Pytest fixture topic name for subscriber testing.
 
@@ -58,7 +58,7 @@ def fixture_topic_one() -> str:
     return "/base/topictestone"
 
 
-@pytest.fixture
+@pytest.fixture()
 def fixture_callback_one() -> Callable[[mqtt.Client, Dict[Any, Any], Any], None]:
     """Pytest fixture that defines a nested funciton that will serve as the callback function
     for the topic one test.
@@ -86,7 +86,7 @@ def fixture_callback_one() -> Callable[[mqtt.Client, Dict[Any, Any], Any], None]
     return _callback_one
 
 
-@pytest.fixture
+@pytest.fixture()
 def fixture_payload_one() -> str:
     """Pytest fixture that defines the payload to be published to the fixture_topic_one topic.
 
@@ -106,7 +106,7 @@ def fixture_topic_two() -> str:
     return "/base/topictesttwo"
 
 
-@pytest.fixture
+@pytest.fixture()
 def fixture_callback_two() -> Callable[[mqtt.Client, Dict[Any, Any], Any], None]:
     """Pytest fixture that defines a nested funciton that will serve as the callback function
     for multiple subscriber test.
@@ -134,7 +134,7 @@ def fixture_callback_two() -> Callable[[mqtt.Client, Dict[Any, Any], Any], None]
     return _callback_two
 
 
-@pytest.fixture
+@pytest.fixture()
 def fixture_heartbeat_payload() -> str:
     """Pytest fixture that defines the payload published to the heartbeat topic name defined
     in the BaseMQTTPubSub constructor.
@@ -146,7 +146,7 @@ def fixture_heartbeat_payload() -> str:
     return "Base Alive"
 
 
-@pytest.fixture
+@pytest.fixture()
 def fixture_heartbeat_callback() -> Callable[[mqtt.Client, Dict[Any, Any], Any], None]:
     """pytest fixture that returns a callback for the heartbeat topic to verify that
     the published payload has been recieved correcrtly and shows and example usage of


### PR DESCRIPTION
This PR ads 3 python code checkers:
- `black`: a code formatter that we should begin to use for all `core` work and enforces this formatting.
- `mypy`: a typing checker that enforces proper python3 typing. I've ignored some checks for overly-nitpicky `mypy` behavior. 
- `pylint`: for standard python linting enforcement.