### PR TITLE
Pass log level

### DIFF
--- a/core/base_mqtt_pub_sub.py
+++ b/core/base_mqtt_pub_sub.py
@@ -5,7 +5,6 @@ This is very much a working document and is under active development.
 import json
 from typing import Callable, Any, Dict, List, Union
 import paho.mqtt.client as mqtt
-import logging
 import coloredlogs
 
 
@@ -21,6 +20,7 @@ class BaseMQTTPubSub:
     REGISTRATION_TOPIC = "/registration"
     HEARTBEAT_TOPIC = "/heartbeat"
     HEARTBEAT_FREQUENCY = 10  # seconds
+    COLORED_LOGS_LEVEL = "INFO"
     COLORED_LOGS_STYLES = {
         "critical": {"bold": True, "color": "red"},
         "debug": {"color": "green"},
@@ -41,6 +41,7 @@ class BaseMQTTPubSub:
         registration_topic: str = REGISTRATION_TOPIC,
         heartbeat_topic: str = HEARTBEAT_TOPIC,
         heartbeat_frequency: int = HEARTBEAT_FREQUENCY,
+        colored_logs_level: str = COLORED_LOGS_LEVEL,
         colored_logs_styles: Dict[str, Any] = COLORED_LOGS_STYLES,
     ) -> None:
         """BaseMQTTPubSub constructor takes constants for the config filepath, heartbeat channel,
@@ -66,7 +67,7 @@ class BaseMQTTPubSub:
         self.heartbeat_frequency = heartbeat_frequency
 
         coloredlogs.install(
-            level=logging.INFO,
+            level=colored_logs_level,
             fmt="%(asctime)s.%(msecs)03d \033[0;90m%(levelname)-8s "
             ""
             "\033[0;36m%(filename)-18s%(lineno)3d\033[00m "


### PR DESCRIPTION
This change allows the log level to be passed as a keyword argument to the BaseMQTTPubSub instantiation function.

The [Python Logging HOWTO](https://docs.python.org/3/howto/logging.html) indicates that print() is the best tool to "Display console output for ordinary usage of a command line script or program”, while [logging.info](https://github.com/IQTLabs/edgetech-core/compare/main...ralatsdc:rl/logging.info)() (or logging.debug() for very detailed output for diagnostic purposes) is the best tool to "Report events that occur during normal operation of a program (e.g. for status monitoring or fault investigation)”.

The EdgeTech modules need to report events during normal operation, and so logging, rather than print, is the best tool. The distinction between “INFO” and “DEBUG” is especially useful when developing and operating these modules.
